### PR TITLE
BUGFIX: Mosaic does not work in Qt GUI

### DIFF
--- a/app/otbMosaic.cxx
+++ b/app/otbMosaic.cxx
@@ -1102,12 +1102,13 @@ private:
     const unsigned int nImages = imagesList->Size();
     const unsigned int nMasks = statsVectorDataList->Size();
     const unsigned int nCutline = cutVectorDataList->Size();
-    if ( nCutline != 0 && nCutline != nImages)
+
+    if (cutVectorDataList->HasValue() && nCutline != nImages)
       {
       otbAppLogFATAL("Number of input cutlines (" << nCutline
                                                   << ") should be equal to number of images (" << nImages << ")");
       }
-    if ( nMasks != 0 && nMasks != nImages)
+    if (statsVectorDataList->HasValue() && nMasks != nImages)
       {
       otbAppLogFATAL("Number of input masks (" << nMasks
                                                << ") should be equal to number of images (" << nImages << ")");
@@ -1144,7 +1145,7 @@ private:
       }
     else
       {
-      if (nMasks != 0)
+      if (statsVectorDataList->HasValue())
         {
 
         // Write binary masks used for statistics computation
@@ -1243,7 +1244,7 @@ private:
       otbAppLogINFO("Composition method is set to none. Skipping distance map images computation.");
 
       // Compute binary masks for cutline, if any
-      if (nCutline != 0)
+      if (cutVectorDataList->HasValue())
         {
         otbAppLogINFO("Computing masks images for cutline... ");
         binaryMaskForCutlineFileNameList.clear();
@@ -1267,7 +1268,7 @@ private:
         otbAppLogINFO("Performing simple composition method in rgb color space");
 
         // Mask if needed
-        if (nCutline != 0)
+        if (cutVectorDataList->HasValue())
           {
           // Connect masks readers to maskfilters
           m_MaskImageFilterForCutline =  CreateConnectedFilterArray<RGB2LABFilterType,MaskReaderType, MaskImageFilterType>(
@@ -1296,7 +1297,7 @@ private:
         otbAppLogINFO("Performing simple composition method in radiometric color space");
 
         // Mask if needed
-        if (nCutline != 0)
+        if (cutVectorDataList->HasValue())
           {
           // Connect masks readers to maskfilters
           m_MaskImageFilterForCutline =  CreateConnectedFilterArrayToInput<MaskReaderType, MaskImageFilterType>(
@@ -1326,7 +1327,7 @@ private:
       for (unsigned int i = 0 ; i < nImages ; i++)
         {
         string outputFileName = GenerateFileName("tmp_distance_image", i);
-        if (nCutline != 0)
+        if (cutVectorDataList->HasValue())
           {
           WriteDistanceImageFromCutline(imagesList->GetNthElement(i),
                                         cutVectorDataList->GetNthElement(i), outputFileName);

--- a/app/otbMosaic.cxx
+++ b/app/otbMosaic.cxx
@@ -1103,12 +1103,12 @@ private:
     const unsigned int nMasks = statsVectorDataList->Size();
     const unsigned int nCutline = cutVectorDataList->Size();
 
-    if (cutVectorDataList->HasValue() && nCutline != nImages)
+    if (GetParameterByKey("vdcut")->HasValue() && nCutline != nImages)
       {
       otbAppLogFATAL("Number of input cutlines (" << nCutline
                                                   << ") should be equal to number of images (" << nImages << ")");
       }
-    if (statsVectorDataList->HasValue() && nMasks != nImages)
+    if (GetParameterByKey("vdstats")->HasValue() && nMasks != nImages)
       {
       otbAppLogFATAL("Number of input masks (" << nMasks
                                                << ") should be equal to number of images (" << nImages << ")");
@@ -1145,7 +1145,7 @@ private:
       }
     else
       {
-      if (statsVectorDataList->HasValue())
+      if (GetParameterByKey("vdstats")->HasValue())
         {
 
         // Write binary masks used for statistics computation
@@ -1244,7 +1244,7 @@ private:
       otbAppLogINFO("Composition method is set to none. Skipping distance map images computation.");
 
       // Compute binary masks for cutline, if any
-      if (cutVectorDataList->HasValue())
+      if (GetParameterByKey("vdcut")->HasValue())
         {
         otbAppLogINFO("Computing masks images for cutline... ");
         binaryMaskForCutlineFileNameList.clear();
@@ -1268,7 +1268,7 @@ private:
         otbAppLogINFO("Performing simple composition method in rgb color space");
 
         // Mask if needed
-        if (cutVectorDataList->HasValue())
+        if (GetParameterByKey("vdcut")->HasValue())
           {
           // Connect masks readers to maskfilters
           m_MaskImageFilterForCutline =  CreateConnectedFilterArray<RGB2LABFilterType,MaskReaderType, MaskImageFilterType>(
@@ -1297,7 +1297,7 @@ private:
         otbAppLogINFO("Performing simple composition method in radiometric color space");
 
         // Mask if needed
-        if (cutVectorDataList->HasValue())
+        if (GetParameterByKey("vdcut")->HasValue())
           {
           // Connect masks readers to maskfilters
           m_MaskImageFilterForCutline =  CreateConnectedFilterArrayToInput<MaskReaderType, MaskImageFilterType>(
@@ -1327,7 +1327,7 @@ private:
       for (unsigned int i = 0 ; i < nImages ; i++)
         {
         string outputFileName = GenerateFileName("tmp_distance_image", i);
-        if (cutVectorDataList->HasValue())
+        if (GetParameterByKey("vdcut")->HasValue())
           {
           WriteDistanceImageFromCutline(imagesList->GetNthElement(i),
                                         cutVectorDataList->GetNthElement(i), outputFileName);


### PR DESCRIPTION
Behavior of Mosaic application is not the same in cli or gui. With the current version, not providing a cut line files as input leads to the exception:

Application.logger (FATAL) Number of input cutlines (1)
should be equal to number of images (3) 

Long story short, the test in the application to check if VectorDataList is empty is not correct as there is a  null inserted in the vector data list in Qt.

Using  GetParameterByKey("vdxxx")->HasValue()  instead of xxxVectorDataList->Size() != 0 seems to fix the issue.