### PR TITLE
Replace unaryFunctorImageFilter by functorImageFilter

### DIFF
--- a/app/otbMosaic.cxx
+++ b/app/otbMosaic.cxx
@@ -33,7 +33,7 @@
 #include "itkNearestNeighborInterpolateImageFunction.h"
 
 // Functors for lab <--> rgb color spaces
-#include "otbUnaryFunctorImageFilter.h"
+#include "otbFunctorImageFilter.h"
 #include "otbMosaicFunctors.h"
 
 // Masks
@@ -131,10 +131,8 @@ public:
       FloatVectorImageType::PixelType>                                                 LAB2RGBFunctor;
   typedef otb::Functor::RGB2LAB<FloatVectorImageType::PixelType,
       FloatVectorImageType::PixelType>                                                 RGB2LABFunctor;
-  typedef otb::UnaryFunctorImageFilter<FloatVectorImageType,FloatVectorImageType,
-      RGB2LABFunctor>                                                                  RGB2LABFilterType;
-  typedef otb::UnaryFunctorImageFilter<FloatVectorImageType,FloatVectorImageType,
-      LAB2RGBFunctor>                                                                  LAB2RGBFilterType;
+  typedef otb::FunctorImageFilter<RGB2LABFunctor>                                      RGB2LABFilterType;
+  typedef otb::FunctorImageFilter<LAB2RGBFunctor>                                      LAB2RGBFilterType;
 
   /** Interpolators typedefs */
   typedef itk::LinearInterpolateImageFunction<FloatVectorImageType, double>            LinearInterpolationType;

--- a/include/otbMosaicFunctors.h
+++ b/include/otbMosaicFunctors.h
@@ -94,9 +94,9 @@ public:
     return output;
   }
 
-  inline unsigned int GetOutputSize(){
+  size_t OutputSize(const std::array<size_t,1> &) const {
     return 3;
-  }
+  } 
 
 private:
   vnl_matrix<double> M;
@@ -185,7 +185,7 @@ public:
     return output;
   }
 
-  inline unsigned int GetOutputSize(){
+  inline size_t OutputSize(const std::array<size_t,1> &) const {
     return 3;
   }
 

--- a/otb-module.cmake
+++ b/otb-module.cmake
@@ -5,6 +5,7 @@ otb_module(Mosaic
     OTBCommon
     OTBApplicationEngine
     OTBConversion
+    OTBFunctor
   TEST_DEPENDS
     OTBTestKernel
     OTBCommandLine


### PR DESCRIPTION
otb::UnaryFunctorImageFilter has been removed and should be replaced by the generic FunctorImageFilter.

See: 
https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/merge_requests/427
https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/issues/1821